### PR TITLE
Bookend Data with PacketMarker

### DIFF
--- a/src/PacketSerial.h
+++ b/src/PacketSerial.h
@@ -121,6 +121,7 @@ public:
                                                     size, 
                                                     _encodeBuffer);
 
+            _serial->write(PacketMarker);
             _serial->write(_encodeBuffer, numEncoded);
             _serial->write(PacketMarker);
     }


### PR DESCRIPTION
This change ensures encoded data will be detected by the receiver even if other non-encoded data or bad data is being received on the same Serial Port.  (For example, a human readable serial.print() directly before a PacketSerial send on the Sender).

If using a single PacketMarker is by design, I would suggest updating the documentation to say direct usage of the serial port is not allowed if using PacketSerial on the same serial port.  Right now it says it is only not-advised.

Either way, thanks for an excellent library!  I used it with CRC8 from Teensy's OneWire library for extremely robust serial transmission.