### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Christopher Baker <info@christopherbaker.net>
 maintainer=Christopher Baker <info@christopherbaker.net>
 sentence=A small, efficient library for sending serial data packets.
 paragraph=PacketSerial is an small, efficient, library that allows Arduinos to send and receive serial data packets that include bytes with any value (0-255).  A packet is simply an array of bytes.
+category=Communication
 url=https://github.com/bakercp/PacketSerial
 architectures=avr


### PR DESCRIPTION
Fixes the`WARNING: Category '' in library PacketSerial is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you prefer a different category I'm happy to change it to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.