### PR TITLE
Add a baton to the handler callback

### DIFF
--- a/src/PacketSerial.h
+++ b/src/PacketSerial.h
@@ -40,7 +40,7 @@ public:
     PacketSerial_():
         _recieveBufferIndex(0),
         _serial(0),
-        _onPacketFunction(0)
+        _onPacket {0, 0, 0}
     {
     }
 
@@ -91,7 +91,7 @@ public:
 
             if (data == PacketMarker)
             {
-                if (_onPacketFunction)
+                if ((_onPacket.hasBaton &&  _onPacket.batonFunction) || (!_onPacket.hasBaton &&   _onPacket.function))
                 {
                     uint8_t _decodeBuffer[_recieveBufferIndex];
 
@@ -106,7 +106,7 @@ public:
                     else
                     {
                         _onPacket.function(_decodeBuffer, numDecoded);
-                    }   
+                    }
                 }
 
                 _recieveBufferIndex = 0;
@@ -166,9 +166,9 @@ private:
         bool hasBaton;
         void* baton;
         union {
-            PacketHandlerFunctionWithBaton function;
-            PacketHandlerFunction batonFunction;
-        }
+            PacketHandlerFunction function;
+            PacketHandlerFunctionWithBaton batonFunction;
+        };
     } _onPacket;
 };
 


### PR DESCRIPTION
Note that unless we want to break backwards compatibility, we need to support functions with and without batons, hence the union here.


Why this is useful:

```C++

class MyClassWithAHandler;

void _handle(const uint8_t* buffer, size_t size, void* baton) {
   auto this_ = static_cast<MyClassWithAHandler*>(baton);
   this_->handle(buffer, size);
}

class MyClassWithAHandler {
public:
    PacketHandler _handler;
    MyClassWithAHandler() {
        _handler.setPacketHandler(_handle, this);
    }
    void handle(const uint8_t* buffer, size_t size) {

    }
}