### PR TITLE
Removed extra SLIP::END marker

### DIFF
--- a/src/Encoding/SLIP.h
+++ b/src/Encoding/SLIP.h
@@ -86,8 +86,6 @@ public:
             }
         }
 
-        encoded[write_index++] = END;
-
         return write_index;
     }
 


### PR DESCRIPTION
Proper fix for #11.
Fix proposed previously in #7 is incorrect.
