### PR TITLE
Supporting the NO_GLOBAL_SERIAL global definition

### DIFF
--- a/src/PacketSerial.h
+++ b/src/PacketSerial.h
@@ -84,13 +84,13 @@ public:
     /// \sa https://www.arduino.cc/en/Serial/Begin
     void begin(unsigned long speed)
     {
-		#if !defined(NO_GLOBAL_SERIAL)
+        #if !defined(NO_GLOBAL_SERIAL)
         Serial.begin(speed);
         #if ARDUINO >= 100 && !defined(CORE_TEENSY)
         while (!Serial) {;}
         #endif
         setStream(&Serial);
-		#endif
+        #endif
     }
 
     /// \brief Deprecated. Use setStream() to configure a non-default port.

--- a/src/PacketSerial.h
+++ b/src/PacketSerial.h
@@ -84,11 +84,13 @@ public:
     /// \sa https://www.arduino.cc/en/Serial/Begin
     void begin(unsigned long speed)
     {
+		#if !defined(NO_GLOBAL_SERIAL)
         Serial.begin(speed);
         #if ARDUINO >= 100 && !defined(CORE_TEENSY)
         while (!Serial) {;}
         #endif
         setStream(&Serial);
+		#endif
     }
 
     /// \brief Deprecated. Use setStream() to configure a non-default port.


### PR DESCRIPTION
# NO_GLOBAL_SERIAL

..is a global definition on the ESP32 Arduino platform which skips defining the Serial, Serial1 and Serial2 objects, leaving the user free to define these themselves. This is a great way of ensuring no other library uses a Serial port for anything we don't want it to, as it immediately generates a compile error.

Unfortunately the legacy begin() function is one of those functions that reference the global Serial object.
So, I forked and added an #if defined(NO_GLOBAL_SERIAL) block inside the legacy begin() function so that PacketSerial is aware of this flag and does not try to link against the Serial object that doesn't exist. That's the only change I've made. The library itself works beautifully, very useful, thank you for making it!